### PR TITLE
Changed benchmark data to use inline data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "iai",
+ "rand",
 ]
 
 [[package]]
@@ -167,6 +168,17 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "half"
@@ -318,6 +330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +351,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -483,6 +531,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dev-dependencies]
 iai = "0.1"
 criterion = "0.3.6"
+rand = "0.8.5"
 
 [[bench]]
 name = "vtbl_bench"

--- a/benches/iai_bench.rs
+++ b/benches/iai_bench.rs
@@ -6,14 +6,14 @@ use clean_code::shapes::{total_area_union, ShapeType};
 use iai::black_box;
 
 fn iai_vtbl() -> f32 {
-    let circle = Circle::new(3.0);
-    let square = Square::new(2.0);
-    let triangle = Triangle::new(3.0, 2.0);
-    let rectangle = Rectangle::new(4.0, 2.0);
+    let circle = Box::new(Circle::new(3.0));
+    let square = Box::new(Square::new(2.0));
+    let triangle = Box::new(Triangle::new(3.0, 2.0));
+    let rectangle = Box::new(Rectangle::new(4.0, 2.0));
 
-    let shapes: Vec<&dyn Shape> = vec![&circle, &square, &triangle, &rectangle];
+    let shapes: Vec<Box<dyn Shape>> = vec![circle, square, triangle, rectangle];
 
-    total_area_vtbl(&black_box::<Vec<&dyn Shape>>(shapes))
+    total_area_vtbl(&black_box::<Vec<Box<dyn Shape>>>(shapes))
 }
 
 fn iai_area_switch() -> f32 {
@@ -23,13 +23,13 @@ fn iai_area_switch() -> f32 {
     let triangle_union = ShapeUnion::new(ShapeType::Triangle, 7.0, 2.0);
 
     let shapes_union = vec![
-        &circle_union,
-        &square_union,
-        &rectangle_union,
-        &triangle_union,
+        circle_union,
+        square_union,
+        rectangle_union,
+        triangle_union,
     ];
 
-    total_area_switch(&black_box::<Vec<&ShapeUnion>>(shapes_union))
+    total_area_switch(&black_box::<Vec<ShapeUnion>>(shapes_union))
 }
 
 fn iai_switch_and_lookup_table() -> f32 {
@@ -39,13 +39,13 @@ fn iai_switch_and_lookup_table() -> f32 {
     let triangle_union = ShapeUnion::new(ShapeType::Triangle, 7.0, 2.0);
 
     let shapes_union = vec![
-        &circle_union,
-        &square_union,
-        &rectangle_union,
-        &triangle_union,
+        circle_union,
+        square_union,
+        rectangle_union,
+        triangle_union,
     ];
 
-    total_area_union(&black_box::<Vec<&ShapeUnion>>(shapes_union))
+    total_area_union(&black_box::<Vec<ShapeUnion>>(shapes_union))
 }
 
 fn iai_rust_enums() -> f32 {
@@ -53,9 +53,9 @@ fn iai_rust_enums() -> f32 {
     let ss_rust = ShapeRustEnum::Square(Square::new(4.0));
     let rr_rust = ShapeRustEnum::Rectangle(Rectangle::new(2.0, 4.0));
     let tt_rust = ShapeRustEnum::Triangle(Triangle::new(5.0, 3.0));
-    let shapes_rust_enum: Vec<&ShapeRustEnum> = vec![&cc_rust, &ss_rust, &rr_rust, &tt_rust];
+    let shapes_rust_enum: Vec<ShapeRustEnum> = vec![cc_rust, ss_rust, rr_rust, tt_rust];
 
-    total_area_rust(&black_box::<Vec<&ShapeRustEnum>>(shapes_rust_enum))
+    total_area_rust(&black_box::<Vec<ShapeRustEnum>>(shapes_rust_enum))
 }
 
 iai::main!(

--- a/benches/vtbl_bench.rs
+++ b/benches/vtbl_bench.rs
@@ -1,10 +1,12 @@
-use clean_code::shapes::ShapeType;
 use clean_code::shapes::{
     total_area_rust, total_area_switch, total_area_union, total_area_vtbl, Circle, Rectangle,
     Shape, ShapeRustEnum, ShapeUnion, Square, Triangle,
 };
+use clean_code::shapes::{total_area_separate, ShapeType};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::seq::SliceRandom;
+use rand::Rng;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("reduced-sample-size");
@@ -12,20 +14,39 @@ fn criterion_benchmark(c: &mut Criterion) {
         .sample_size(30)
         .measurement_time(std::time::Duration::from_secs(45));
 
-    const ARRAY_SIZE: u32 = 100_000;
+    const ARRAY_SIZE: usize = 100_000;
 
-    let circle = Circle::new(3.0);
-    let square = Square::new(2.0);
-    let triangle = Triangle::new(3.0, 2.0);
-    let rectangle = Rectangle::new(4.0, 2.0);
-    let mut shapes: Vec<&dyn Shape> = Vec::new();
+    let mut rng = rand::thread_rng();
 
-    for _ in 0..ARRAY_SIZE {
-        shapes.push(&circle);
-        shapes.push(&square);
-        shapes.push(&triangle);
-        shapes.push(&rectangle);
+    let circle = Box::new(Circle::new(3.0));
+    let square = Box::new(Square::new(2.0));
+    let triangle = Box::new(Triangle::new(3.0, 2.0));
+    let rectangle = Box::new(Rectangle::new(4.0, 2.0));
+    let mut shapes: Vec<Box<dyn Shape>> = Vec::new();
+    let mut shuffled_shapes: Vec<Box<dyn Shape>> = Vec::new();
+
+    for _ in 0..4 * ARRAY_SIZE {
+        match rng.gen_range(0..4) {
+            0 => shapes.push(circle.clone()),
+            1 => shapes.push(square.clone()),
+            2 => shapes.push(triangle.clone()),
+            3 => shapes.push(rectangle.clone()),
+            _ => unreachable!(),
+        }
     }
+
+    for _ in 0..4 * ARRAY_SIZE {
+        match rng.gen_range(0..4) {
+            0 => shuffled_shapes.push(circle.clone()),
+            1 => shuffled_shapes.push(square.clone()),
+            2 => shuffled_shapes.push(triangle.clone()),
+            3 => shuffled_shapes.push(rectangle.clone()),
+            _ => unreachable!(),
+        }
+    }
+
+    // shuffle to try and trick cache
+    shuffled_shapes.shuffle(&mut rng);
 
     let circle_union = ShapeUnion::new(ShapeType::Circle, 3.0, 3.0);
     let square_union = ShapeUnion::new(ShapeType::Square, 3.0, 2.0);
@@ -33,28 +54,43 @@ fn criterion_benchmark(c: &mut Criterion) {
     let triangle_union = ShapeUnion::new(ShapeType::Triangle, 7.0, 2.0);
     let mut shapes_union = Vec::new();
 
-    for _ in 0..ARRAY_SIZE {
-        shapes_union.push(&circle_union);
-        shapes_union.push(&triangle_union);
-        shapes_union.push(&rectangle_union);
-        shapes_union.push(&square_union);
+    for _ in 0..4 * ARRAY_SIZE {
+        match rng.gen_range(0..4) {
+            0 => shapes_union.push(circle_union.clone()),
+            1 => shapes_union.push(square_union.clone()),
+            2 => shapes_union.push(triangle_union.clone()),
+            3 => shapes_union.push(rectangle_union.clone()),
+            _ => unreachable!(),
+        }
     }
 
     let cc_rust = ShapeRustEnum::Circle(Circle::new(3.0));
     let ss_rust = ShapeRustEnum::Square(Square::new(4.0));
     let rr_rust = ShapeRustEnum::Rectangle(Rectangle::new(2.0, 4.0));
     let tt_rust = ShapeRustEnum::Triangle(Triangle::new(5.0, 3.0));
-    let mut shapes_rust_enum: Vec<&ShapeRustEnum> = Vec::new();
+    let mut shapes_rust_enum: Vec<ShapeRustEnum> = Vec::new();
 
-    for _ in 0..ARRAY_SIZE {
-        shapes_rust_enum.push(&cc_rust);
-        shapes_rust_enum.push(&ss_rust);
-        shapes_rust_enum.push(&rr_rust);
-        shapes_rust_enum.push(&tt_rust);
+    for _ in 0..4 * ARRAY_SIZE {
+        match rng.gen_range(0..4) {
+            0 => shapes_rust_enum.push(cc_rust.clone()),
+            1 => shapes_rust_enum.push(ss_rust.clone()),
+            2 => shapes_rust_enum.push(rr_rust.clone()),
+            3 => shapes_rust_enum.push(tt_rust.clone()),
+            _ => unreachable!(),
+        }
     }
+
+    let circles = vec![Circle::new(3.0); ARRAY_SIZE];
+    let squares = vec![Square::new(4.0); ARRAY_SIZE];
+    let rectangles = vec![Rectangle::new(2.0, 4.0); ARRAY_SIZE];
+    let triangles = vec![Triangle::new(5.0, 3.0); ARRAY_SIZE];
 
     group.bench_function("Dynamic dispatch (VTBL)", |b| {
         b.iter(|| total_area_vtbl(black_box(&shapes)))
+    });
+
+    group.bench_function("Dynamic dispatch (VTBL) shuffled", |b| {
+        b.iter(|| total_area_vtbl(black_box(&shuffled_shapes)))
     });
 
     group.bench_function("GS with switch", |b| {
@@ -67,6 +103,10 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("Rust enums", |b| {
         b.iter(|| total_area_rust(black_box(&shapes_rust_enum)))
+    });
+
+    group.bench_function("Separate data", |b| {
+        b.iter(|| total_area_separate(black_box((&circles, &squares, &rectangles, &triangles))))
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,1 @@
 pub mod shapes;
-
-fn main() {
-    println!("Hello, world!");
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!")
-}

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -1,4 +1,4 @@
-pub fn total_area_union(shape_union: &[&ShapeUnion]) -> f32 {
+pub fn total_area_union(shape_union: &[ShapeUnion]) -> f32 {
     let mut accum: f32 = 0.0;
 
     shape_union
@@ -8,7 +8,7 @@ pub fn total_area_union(shape_union: &[&ShapeUnion]) -> f32 {
     accum
 }
 
-pub fn total_area_switch(shape_union: &[&ShapeUnion]) -> f32 {
+pub fn total_area_switch(shape_union: &[ShapeUnion]) -> f32 {
     let mut accum: f32 = 0.0;
 
     shape_union
@@ -18,7 +18,7 @@ pub fn total_area_switch(shape_union: &[&ShapeUnion]) -> f32 {
     accum
 }
 
-const CTABLE: [f32; ShapeType::Count as usize] = [1.0, 1.0, 0.5, std::f32::consts::PI];
+const CTABLE: [f32; ShapeType::COUNT] = [1.0, 1.0, 0.5, std::f32::consts::PI];
 fn get_area_union(shape: &ShapeUnion) -> f32 {
     CTABLE[shape.shape_type as usize] * shape.width * shape.height
 }
@@ -33,9 +33,9 @@ fn get_area_switch(shape: &ShapeUnion) -> f32 {
     }
 }
 
-pub fn total_area_vtbl<T>(shapes: &[&T]) -> f32
+pub fn total_area_vtbl<T>(shapes: &[T]) -> f32
 where
-    T: Shape + ?Sized,
+    T: Shape,
 {
     let mut accum: f32 = 0.0;
 
@@ -44,7 +44,7 @@ where
     accum
 }
 
-pub fn total_area_rust(shapes: &[&ShapeRustEnum]) -> f32 {
+pub fn total_area_rust(shapes: &[ShapeRustEnum]) -> f32 {
     let mut accum: f32 = 0.0;
 
     shapes.iter().for_each(|shape| accum += shape.get_area());
@@ -52,7 +52,14 @@ pub fn total_area_rust(shapes: &[&ShapeRustEnum]) -> f32 {
     accum
 }
 
-#[derive(Copy, Clone)]
+pub fn total_area_separate(shapes: (&[Circle], &[Square], &[Rectangle], &[Triangle])) -> f32 {
+    total_area_vtbl(shapes.0) +
+    total_area_vtbl(shapes.1) +
+    total_area_vtbl(shapes.2) +
+    total_area_vtbl(shapes.3)
+}
+
+#[derive(Debug, Copy, Clone)]
 pub enum ShapeType {
     Square,
     Rectangle,
@@ -61,6 +68,12 @@ pub enum ShapeType {
     Count,
 }
 
+impl ShapeType {
+    const COUNT: usize = 4;
+}
+
+
+#[derive(Debug, Clone)]
 pub enum ShapeRustEnum {
     Square(Square),
     Rectangle(Rectangle),
@@ -68,6 +81,8 @@ pub enum ShapeRustEnum {
     Circle(Circle),
 }
 
+
+#[derive(Debug, Clone)]
 pub struct ShapeUnion {
     shape_type: ShapeType,
     width: f32,
@@ -99,6 +114,7 @@ impl Shape for ShapeRustEnum {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Square {
     side: f32,
 }
@@ -115,6 +131,7 @@ impl Shape for Square {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Rectangle {
     width: f32,
     height: f32,
@@ -132,6 +149,7 @@ impl Shape for Rectangle {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Triangle {
     base: f32,
     height: f32,
@@ -149,6 +167,7 @@ impl Shape for Triangle {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Circle {
     radius: f32,
 }
@@ -162,5 +181,12 @@ impl Circle {
 impl Shape for Circle {
     fn get_area(&self) -> f32 {
         std::f32::consts::PI * self.radius * self.radius
+    }
+}
+
+impl Shape for Box<dyn Shape> {
+    #[inline(always)]
+    fn get_area(&self) -> f32 {
+        (**self).get_area()
     }
 }


### PR DESCRIPTION
I think this data will more accurately reflect how this will be used. Where rather than referencing the same data in the same location repeatedly, it copies the data into the vector. I also added some benchmarks that tweak the data to see the effect on cache and branch prediction.